### PR TITLE
Add models and basic functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ob"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.58"

--- a/src/book_side.rs
+++ b/src/book_side.rs
@@ -1,0 +1,146 @@
+use crate::{
+    OrderId, Price, Qty, {Order, PriceLevel},
+};
+use anyhow::{bail, Result};
+use std::collections::{hash_map::Entry, HashMap};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Ask,
+    Bid,
+}
+
+pub(super) struct BookSide {
+    price_levels: HashMap<Price, PriceLevel>,
+    orders: HashMap<OrderId, Order>,
+}
+
+impl BookSide {
+    /// Constructor function
+    pub(super) fn new() -> Self {
+        Self {
+            price_levels: HashMap::new(),
+            orders: HashMap::new(),
+        }
+    }
+
+    /// Function insert new order into the `BookSide`
+    pub(super) fn insert(&mut self, order: &Order, id: OrderId) {
+        match self.price_levels.entry(order.price) {
+            Entry::Vacant(new_price_lvl) => {
+                let mut price_lvl = PriceLevel::new();
+                price_lvl.insert(order, id);
+                new_price_lvl.insert(price_lvl);
+            }
+            Entry::Occupied(mut price_lvl) => {
+                price_lvl.get_mut().insert(order, id);
+            }
+        }
+        self.orders.insert(id, *order);
+    }
+
+    /// Function removes order with given `OrderId`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the order with given `OrderId` is not present
+    pub(super) fn remove(&mut self, id: OrderId) -> Result<()> {
+        match self.orders.remove(&id) {
+            Some(order) => match self.price_levels.get_mut(&order.price) {
+                Some(price_level) => price_level.remove(id),
+                None => bail!(
+                    "Order with OrderId {id} on PriceLevel {} was not found",
+                    order.price
+                ),
+            },
+            None => bail!("Order with OrderId {id} is not present"),
+        }
+    }
+
+    /// Function gets the best price for the given `Side`
+    ///
+    /// Returns [`None`] if there are no orders on given side
+    pub(super) fn get_best_price(&self) -> Option<Price> {
+        todo!()
+    }
+
+    /// Function gets the total quantity at the given `Price` and `Side` combination
+    pub(super) fn get_total_qty(&self, price: Price) -> Option<Qty> {
+        self.price_levels.get(&price).map(PriceLevel::get_total_qty)
+    }
+
+    /// Function drains orders on the given `Price` and `Side` combination up to the given `Qty`
+    ///
+    /// Returns [`Some`] with orders and total collected `Qty`
+    /// Returns [`None`] if there are no orders on the given `Side` and `Price` combination
+    pub(super) fn get_orders_till_qty(
+        &mut self,
+        price: Price,
+        qty: Qty,
+    ) -> Option<(Vec<Order>, Qty)> {
+        match self.price_levels.get_mut(&price) {
+            Some(mut price_level) => price_level.get_orders_till_qty(qty),
+            None => None,
+        }
+    }
+}
+
+impl Default for BookSide {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{BookSide, Order, OrderId, Side};
+
+    #[test]
+    fn book_side_insert() {
+        // Setup
+        let mut bs = BookSide::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+        let id: OrderId = 1;
+
+        // Act
+        bs.insert(&order, id);
+
+        // Assert
+        assert!(bs.orders.contains_key(&id));
+        assert!(bs.price_levels.contains_key(&price));
+        assert_eq!(bs.get_total_qty(price), Some(qty));
+    }
+
+    #[test]
+    fn book_side_remove() {
+        // Setup
+        let mut bs = BookSide::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+        let id: OrderId = 1;
+
+        bs.insert(&order, id);
+
+        // Act
+        assert!(bs.remove(id).is_ok());
+        assert!(!bs.orders.contains_key(&id));
+    }
+
+    #[test]
+    fn book_side_remove_unknown_id() {
+        // Setup
+        let mut bs = BookSide::default();
+        let id: OrderId = 1;
+
+        // Act
+        let ret = bs.remove(id);
+
+        // Assert
+        assert!(ret.is_err());
+    }
+}

--- a/src/book_side.rs
+++ b/src/book_side.rs
@@ -157,4 +157,54 @@ mod test {
         // Assert
         assert!(ret.is_err());
     }
+
+    #[test]
+    fn book_side_get_best_price_ask() {
+        // Setup
+        let side = Side::Ask;
+        let mut bs = BookSide::new(side);
+        // First order
+        let price = 69;
+        let qty = 420;
+        let o1 = Order { price, qty, side };
+        let id: OrderId = 1;
+        bs.insert(&o1, id);
+
+        // Second order
+        let price = 70;
+        let o2 = Order { price, qty, side };
+        let id: OrderId = 2;
+        bs.insert(&o2, id);
+
+        // Act
+        let best_price = bs.get_best_price();
+
+        // Assert
+        assert_eq!(best_price, Some(&o2.price));
+    }
+
+    #[test]
+    fn book_side_get_best_price_bid() {
+        // Setup
+        let side = Side::Bid;
+        let mut bs = BookSide::new(side);
+        // First order
+        let price = 69;
+        let qty = 420;
+        let o1 = Order { price, qty, side };
+        let id: OrderId = 1;
+        bs.insert(&o1, id);
+
+        // Second order
+        let price = 70;
+        let o2 = Order { price, qty, side };
+        let id: OrderId = 2;
+        bs.insert(&o2, id);
+
+        // Act
+        let best_price = bs.get_best_price();
+
+        // Assert
+        assert_eq!(best_price, Some(&o1.price));
+    }
 }

--- a/src/book_side.rs
+++ b/src/book_side.rs
@@ -79,7 +79,7 @@ impl BookSide {
         qty: Qty,
     ) -> Option<(Vec<Order>, Qty)> {
         match self.price_levels.get_mut(&price) {
-            Some(mut price_level) => price_level.get_orders_till_qty(qty),
+            Some(price_level) => price_level.get_orders_till_qty(qty),
             None => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+#![warn(clippy::pedantic)]
+#![allow(unused, clippy::unused_self)]
+mod book_side;
+mod order_book;
+mod price_level;
+mod sequencer;
+
+use book_side::BookSide;
+pub use book_side::Side;
+pub use order_book::{Order, OrderBook};
+use price_level::PriceLevel;
+use sequencer::Sequencer;
+
+type OrderId = u64;
+type Price = u64;
+type Qty = u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::pedantic)]
-#![allow(unused, clippy::unused_self)]
 mod book_side;
 mod order_book;
 mod price_level;

--- a/src/order_book.rs
+++ b/src/order_book.rs
@@ -1,0 +1,183 @@
+use crate::{
+    OrderId, Price, Qty, {BookSide, PriceLevel, Sequencer, Side},
+};
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Order {
+    pub price: Price,
+    pub qty: Qty,
+    pub side: Side,
+}
+
+pub struct OrderBook {
+    asks: BookSide,
+    bids: BookSide,
+    orders: HashMap<OrderId, Order>,
+    sequencer: Sequencer,
+}
+
+impl OrderBook {
+    /// Constructor function
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            asks: BookSide::new(),
+            bids: BookSide::new(),
+            orders: HashMap::new(),
+            sequencer: Sequencer::new(),
+        }
+    }
+
+    /// Function insert a new [`Order`] into the [`OrderBook`]
+    ///
+    /// Example:
+    /// ```
+    /// use ob::{OrderBook, Order, Side};
+    /// let mut ob = OrderBook::new();
+    /// let price = 69;
+    /// let qty = 420;
+    /// let side = Side::Ask;
+    /// let order = Order {
+    ///     price,
+    ///     qty,
+    ///     side
+    /// };
+    ///
+    /// ob.insert(order);
+    ///
+    /// ```
+    pub fn insert(&mut self, order: Order) -> OrderId {
+        let id = self.sequencer.get_next_id();
+        match order.side {
+            Side::Ask => self.asks.insert(&order, id),
+            Side::Bid => self.bids.insert(&order, id),
+        };
+        self.orders.insert(id, order);
+        id
+    }
+
+    /// Function removes an [`Order`] according to an `OrderId`
+    ///
+    /// # Errors
+    /// Returns [`Err`] if the order with the given `OrderId` is not present
+    ///
+    /// Example:
+    /// ```
+    /// use ob::{OrderBook};
+    ///
+    /// let mut ob = OrderBook::new();
+    /// let id = 69;
+    ///
+    /// match ob.remove(id) {
+    ///     Ok(()) => (), // Order Removed!
+    ///     Err(e) => (), // OrderId not found!
+    /// }
+    /// ```
+    pub fn remove(&mut self, id: OrderId) -> Result<()> {
+        match self.orders.remove(&id) {
+            Some(order) => match order.side {
+                Side::Ask => self.asks.remove(id),
+                Side::Bid => self.bids.remove(id),
+            },
+            None => bail!("Order with OrderId {id} is not present"),
+        }
+    }
+
+    /// Function gets the best price for the given `Side`
+    ///
+    /// Returns [`Some`] `Price` on success
+    ///
+    /// Returns [`None`] if there are no orders on given side
+    #[must_use]
+    pub fn get_best_price(&self, side: Side) -> Option<Price> {
+        match side {
+            Side::Ask => self.asks.get_best_price(),
+            Side::Bid => self.bids.get_best_price(),
+        }
+    }
+
+    /// Function gets the total quantity at the given `Price` and `Side` combination
+    ///
+    /// Returns [`Some`] `Qty` on success
+    ///
+    /// Returns [`None`] if there are no orders on given `Side` and `Price` combination
+    #[must_use]
+    pub fn get_total_qty(&self, price: Price, side: Side) -> Option<Qty> {
+        match side {
+            Side::Ask => self.asks.get_total_qty(price),
+            Side::Bid => self.bids.get_total_qty(price),
+        }
+    }
+
+    /// Function drains orders on the given `Price` and `Side` combination up to the given `Qty`
+    ///
+    /// Returns [`Some`] [`Vec`] of [`Order`] and total collected `Qty`
+    ///
+    /// Returns [`None`] if there are no orders on the given `Side` and `Price` combination
+    pub fn get_orders_till_qty(
+        &mut self,
+        price: Price,
+        side: Side,
+        qty: Qty,
+    ) -> Option<(Vec<Order>, Qty)> {
+        match side {
+            Side::Ask => self.asks.get_orders_till_qty(price, qty),
+            Side::Bid => self.bids.get_orders_till_qty(price, qty),
+        }
+    }
+}
+
+impl Default for OrderBook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Order, OrderBook, Side};
+
+    #[test]
+    fn order_book_insert() {
+        // Setup
+        let mut ob = OrderBook::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+
+        // Act
+        let order_id = ob.insert(order);
+
+        // Assert
+        assert_eq!(order_id, 1);
+        assert!(ob.orders.contains_key(&order_id));
+    }
+
+    #[test]
+    fn order_book_remove() {
+        // Setup
+        let mut ob = OrderBook::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+
+        let id = ob.insert(order);
+
+        // Act
+        let res = ob.remove(id);
+
+        // Assert
+        assert!(res.is_ok());
+        assert!(!ob.orders.contains_key(&id));
+    }
+
+    #[test]
+    fn order_book_remove_unknown_id() {
+        // Setup
+        let mut ob = OrderBook::default();
+    }
+}

--- a/src/order_book.rs
+++ b/src/order_book.rs
@@ -1,5 +1,5 @@
 use crate::{
-    OrderId, Price, Qty, {BookSide, PriceLevel, Sequencer, Side},
+    OrderId, Price, Qty, {BookSide, Sequencer, Side},
 };
 use anyhow::{bail, Result};
 use std::collections::HashMap;

--- a/src/order_book.rs
+++ b/src/order_book.rs
@@ -23,8 +23,8 @@ impl OrderBook {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            asks: BookSide::new(),
-            bids: BookSide::new(),
+            asks: BookSide::new(Side::Ask),
+            bids: BookSide::new(Side::Bid),
             orders: HashMap::new(),
             sequencer: Sequencer::new(),
         }
@@ -91,7 +91,7 @@ impl OrderBook {
     ///
     /// Returns [`None`] if there are no orders on given side
     #[must_use]
-    pub fn get_best_price(&self, side: Side) -> Option<Price> {
+    pub fn get_best_price(&self, side: Side) -> Option<&Price> {
         match side {
             Side::Ask => self.asks.get_best_price(),
             Side::Bid => self.bids.get_best_price(),
@@ -137,7 +137,7 @@ impl Default for OrderBook {
 
 #[cfg(test)]
 mod test {
-    use crate::{Order, OrderBook, Side};
+    use crate::{Order, OrderBook, OrderId, Side};
 
     #[test]
     fn order_book_insert() {
@@ -173,5 +173,18 @@ mod test {
         // Assert
         assert!(res.is_ok());
         assert!(!ob.orders.contains_key(&id));
+    }
+
+    #[test]
+    fn order_book_remove_unknown_id() {
+        // Setup
+        let mut ob = OrderBook::default();
+        let id: OrderId = 1;
+
+        // Act
+        let ret = ob.remove(id);
+
+        // Assert
+        assert!(ret.is_err());
     }
 }

--- a/src/order_book.rs
+++ b/src/order_book.rs
@@ -187,4 +187,50 @@ mod test {
         // Assert
         assert!(ret.is_err());
     }
+
+    #[test]
+    fn order_book_get_best_price_ask() {
+        // Setup
+        let side = Side::Ask;
+        let mut ob = OrderBook::new();
+        // First order
+        let price = 69;
+        let qty = 420;
+        let o1 = Order { price, qty, side };
+        ob.insert(o1);
+
+        // Second order
+        let price = 70;
+        let o2 = Order { price, qty, side };
+        ob.insert(o2);
+
+        // Act
+        let best_price = ob.get_best_price(side);
+
+        // Assert
+        assert_eq!(best_price, Some(&o2.price));
+    }
+
+    #[test]
+    fn book_side_get_best_price_bid() {
+        // Setup
+        let side = Side::Bid;
+        let mut ob = OrderBook::new();
+        // First order
+        let price = 69;
+        let qty = 420;
+        let o1 = Order { price, qty, side };
+        ob.insert(o1);
+
+        // Second order
+        let price = 70;
+        let o2 = Order { price, qty, side };
+        ob.insert(o2);
+
+        // Act
+        let best_price = ob.get_best_price(side);
+
+        // Assert
+        assert_eq!(best_price, Some(&o1.price));
+    }
 }

--- a/src/order_book.rs
+++ b/src/order_book.rs
@@ -174,10 +174,4 @@ mod test {
         assert!(res.is_ok());
         assert!(!ob.orders.contains_key(&id));
     }
-
-    #[test]
-    fn order_book_remove_unknown_id() {
-        // Setup
-        let mut ob = OrderBook::default();
-    }
 }

--- a/src/price_level.rs
+++ b/src/price_level.rs
@@ -1,3 +1,4 @@
+#![allow(unused, clippy::unused_self)]
 use crate::{Order, OrderId, Qty};
 use anyhow::{bail, Result};
 use std::collections::{HashMap, VecDeque};

--- a/src/price_level.rs
+++ b/src/price_level.rs
@@ -1,9 +1,6 @@
-use crate::{Order, OrderId, Price, Qty};
+use crate::{Order, OrderId, Qty};
 use anyhow::{bail, Result};
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::LockResult,
-};
+use std::collections::{HashMap, VecDeque};
 
 pub(super) struct PriceLevel {
     queue: VecDeque<Order>,

--- a/src/price_level.rs
+++ b/src/price_level.rs
@@ -1,0 +1,119 @@
+use crate::{Order, OrderId, Price, Qty};
+use anyhow::{bail, Result};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::LockResult,
+};
+
+pub(super) struct PriceLevel {
+    queue: VecDeque<Order>,
+    total_qty: Qty,
+    orders: HashMap<OrderId, Order>,
+}
+
+impl PriceLevel {
+    /// Constructor function
+    pub(super) fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            total_qty: 0,
+            orders: HashMap::new(),
+        }
+    }
+
+    /// Function inserts new `Order` into `PriceLevel`
+    pub(super) fn insert(&mut self, order: &Order, id: OrderId) {
+        self.orders.insert(id, *order);
+        self.queue.push_back(*order);
+        self.total_qty += order.qty;
+    }
+
+    /// Function removes `Order` from `PriceLevel`
+    pub(super) fn remove(&mut self, id: OrderId) -> Result<()> {
+        match self.orders.remove(&id) {
+            Some(order) => {
+                self.total_qty -= order.qty;
+                // Remove order from VecDeque
+                self.queue.retain(|&o| o != order);
+                Ok(())
+            }
+            None => bail!("Order with OrderId {id} not found in PriceLevel"),
+        }
+    }
+
+    pub(super) fn get_total_qty(&self) -> Qty {
+        self.total_qty
+    }
+
+    /// Function drains orders on the given `Side` up to the given `Qty`
+    ///
+    /// Returns [`Some`] with orders and total collected `Qty`
+    /// Returns [`None`] if there are no orders on the given `Side` and `Price` combination
+    pub(super) fn get_orders_till_qty(&mut self, qty: Qty) -> Option<(Vec<Order>, Qty)> {
+        todo!()
+    }
+}
+
+impl Default for PriceLevel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Order, OrderId, PriceLevel, Side};
+
+    #[test]
+    fn price_level_insert() {
+        // Setup
+        let mut pl = PriceLevel::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+        let id: OrderId = 1;
+
+        // Act
+        pl.insert(&order, id);
+
+        // Assert
+        assert_eq!(pl.total_qty, qty);
+        assert_eq!(pl.queue.len(), 1);
+        assert!(pl.orders.contains_key(&id));
+    }
+
+    #[test]
+    fn price_level_remove() {
+        // Setup
+        let mut pl = PriceLevel::default();
+        let price = 69;
+        let qty = 420;
+        let side = Side::Ask;
+        let order = Order { price, qty, side };
+        let id: OrderId = 1;
+
+        pl.insert(&order, id);
+        // Act
+        let ret = pl.remove(id);
+
+        // Assert
+        assert!(ret.is_ok());
+        assert!(!pl.orders.contains_key(&id));
+        assert_eq!(pl.total_qty, 0);
+        assert_eq!(pl.queue.len(), 0);
+    }
+
+    #[test]
+    fn price_level_remove_unknown_id() {
+        // Setup
+        let mut pl = PriceLevel::default();
+        let id: OrderId = 1;
+
+        // Act
+        let ret = pl.remove(id);
+
+        // Assert
+        assert!(ret.is_err());
+    }
+}

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -1,0 +1,19 @@
+use crate::OrderId;
+
+pub(super) struct Sequencer {
+    next_id: OrderId,
+}
+
+impl Sequencer {
+    /// Constructor function
+    pub fn new() -> Self {
+        Self { next_id: 1 }
+    }
+
+    /// Get next available `OrderId`
+    pub fn get_next_id(&mut self) -> OrderId {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}


### PR DESCRIPTION
Closes #1 
# Description
This PR adds basic functionality (add and remove) to the order book and the models that go along with it.

The most granular data structure in the order book is the `PriceLevel` struct, which holds the total_qty at a price level, a `VecDeque` of orders and a `HashMap` of `<OrderId, Order>` for the quick lookup for removal.

Next, we have the `BookSide`, which contains a `HashMap` of `<Price, PriceLevel>` to store the orders at different price points. It also holds a `HashMap` of `<OrderId, Order>` for the quick lookup for removal.

Finally, we have the `OrderBook` struct which holds 2 `BookSide`'s and a `HashMap` of `<OrderId, Order>` for the quick lookup for removal. It also holds a sequencer to generate `OrderId`'s.

Some unit tests have been added for insertions and removals.

There are also some functions that have no function body yet, these will be implemented in a later issue.

## How to run/test
simple run `cargo test` to run all the tests
run `cargo clippy --all-features` for lining

## Dependencies added
`anyhow`: for easy idiomatic error handling